### PR TITLE
Add password protection support for meta description

### DIFF
--- a/src/MetaTags/Description.php
+++ b/src/MetaTags/Description.php
@@ -56,6 +56,12 @@ class Description {
 		$data = get_post_meta( $post_id, 'slim_seo', true );
 		if ( ! empty( $data['description'] ) ) {
 			$this->is_manual = true;
+			
+			/** This mimics the behaviour of `get_the_excerpt` in `/wp-includes/post-template.php` */
+			if ( post_password_required( $post_id ) ) {
+				return __( 'There is no excerpt because this is a protected post.' );
+			}
+			
 			return $data['description'];
 		}
 

--- a/src/MetaTags/Description.php
+++ b/src/MetaTags/Description.php
@@ -59,8 +59,7 @@ class Description {
 			return $data['description'];
 		}
 
-		$post = get_post( $post_id );
-		return $post->post_excerpt ? $post->post_excerpt : $post->post_content;
+		return get_the_excerpt($post_id);
 	}
 
 	private function get_term_value() {

--- a/src/MetaTags/Description.php
+++ b/src/MetaTags/Description.php
@@ -48,7 +48,7 @@ class Description {
 	}
 
 	/**
-	 * Get description from manual meta description input or fallback to post excerpt
+	 * Get custom meta description or fallback to post excerpt or post content
 	 * Make public to allow access from other class. See Integration/WooCommerce.
 	 */
 	public function get_singular_value( $post_id = null ) {
@@ -62,11 +62,11 @@ class Description {
 		$data = get_post_meta( $post_id, 'slim_seo', true );
 		if ( ! empty( $data['description'] ) ) {
 			$this->is_manual = true;
-
 			return $data['description'];
 		}
 
-		return get_the_excerpt($post_id);
+		$post = get_post( $post_id );
+		return $post->post_excerpt ? $post->post_excerpt : $post->post_content;
 	}
 
 	private function get_term_value() {

--- a/src/MetaTags/Description.php
+++ b/src/MetaTags/Description.php
@@ -48,20 +48,21 @@ class Description {
 	}
 
 	/**
-	 * Get description from post excerpt and fallback to post content.
+	 * Get description from manual meta description input or fallback to post excerpt
 	 * Make public to allow access from other class. See Integration/WooCommerce.
 	 */
 	public function get_singular_value( $post_id = null ) {
 		$post_id = $post_id ?: get_queried_object_id();
+
+		// Prevent showing description on password protected posts
+		if ( post_password_required( $post_id ) ) {
+			return __( 'There is no excerpt because this is a protected post.', 'slim-seo' );
+		}
+
 		$data = get_post_meta( $post_id, 'slim_seo', true );
 		if ( ! empty( $data['description'] ) ) {
 			$this->is_manual = true;
-			
-			/** This mimics the behaviour of `get_the_excerpt` in `/wp-includes/post-template.php` */
-			if ( post_password_required( $post_id ) ) {
-				return __( 'There is no excerpt because this is a protected post.' );
-			}
-			
+
 			return $data['description'];
 		}
 


### PR DESCRIPTION
This fixes the case where a description is shown even though it's password protected. This solution also applies the filter `get_the_excerpt` so it might help in other usecases as well.