### PR TITLE
Add divi compatibility (#32)

### DIFF
--- a/src/MetaTags/Helper.php
+++ b/src/MetaTags/Helper.php
@@ -23,6 +23,19 @@ class Helper {
 			'mb_user_profile_info',
 			'mb_relationships',         // MB Relationships.
 			'mbfp-button',              // MB Favorite Posts.
+
+			/**
+			 * Divi
+			 *
+			 * @link https://www.elegantthemes.com/gallery/divi/
+			 */
+			'et_pb_section',
+			'et_pb_row',
+			'et_pb_text',
+			'et_pb_image',
+			'et_pb_slider',
+			'et_pb_slide',
+			'et_pb_gallery',
 		] );
 		$shortcodes_bak = $shortcode_tags;
 		$shortcode_tags = array_diff_key( $shortcode_tags, array_flip( $skipped_shortcodes ) );


### PR DESCRIPTION
As mentioned in #32 Slim SEO does not seem to play well with Divi. This PR adds some of the Divi modules to the `slim_seo_skipped_shortcodes` filter to ensure compatibility with Slim SEO. The list is not complete, I just couldn't find an official source/list of all divi modules.