### PR TITLE
Add composer.lock to repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 vendor
-composer.lock
 *.swp
 .DS_Store
 Thumbs.db

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,18 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "252ba0e2e4d7505201573eadd6bda751",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
+}


### PR DESCRIPTION
The official composer docs recommend you submit your `composer.lock`

> You should commit the composer.lock file to your project repo so that all people working on the project are locked to the same versions of dependencies (more below). This is the main role of the update command.

https://getcomposer.org/doc/01-basic-usage.md