### PR TITLE
Force LF endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-# Normalize EOL=LF
-* text=auto
+# Force LF endings
+* text eol=lf
 
 # Ignore files when export
 .DS_Store export-ignore


### PR DESCRIPTION
I am unfortunately a Windows user and it seems like git automatically converts files to use CRLF instead of LF, which is required by the style guide.

This should force LF endings, regardless of OS.

https://git-scm.com/docs/gitattributes