### PR TITLE
Improve/404 logs

### DIFF
--- a/src/Redirection/Loader.php
+++ b/src/Redirection/Loader.php
@@ -69,7 +69,7 @@ class Loader {
 	public function run_schedule() {
 		$days = (int) Settings::get( 'auto_delete_404_logs' );
 
-		if ( $days !== -1 ) {
+		if ( $days !== -1 && $this->db_log->table_exists() ) {
 			$this->db_log->delete_older_logs( $days );
 		}
 	}


### PR DESCRIPTION
ở hàm `run_wp_schedule`
có thể ko cần check `if ( $days !== -1 && $this->db_log->table_exists() )`
mà chạy luôn `$this->db_log->delete_older_logs( $days );`
nhưng e vẫn để cho chắc chắn hơn