### PR TITLE
Skip `civicrm` shortcode

### DIFF
--- a/src/MetaTags/Helper.php
+++ b/src/MetaTags/Helper.php
@@ -19,6 +19,7 @@ class Helper {
 			'ninja_form',
 			'mailpoet_form',
 			'gravityview',
+			'civicrm',
 
 			// Filter everything.
 			'fe_widget',


### PR DESCRIPTION
Please see https://github.com/civicrm/civicrm-wordpress/pull/307 for details.