### PR TITLE
Fix SureCart issue

### DIFF
--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -96,7 +96,7 @@ class Breadcrumbs {
 	}
 
 	public function get_current_page(): string {
-		return $this->args['display_current'] === 'true' ? $this->current : '';
+		return $this->args['display_current'] === 'true' ? (string) $this->current : '';
 	}
 
 	public function parse(): void {
@@ -115,9 +115,9 @@ class Breadcrumbs {
 		$this->add_link( home_url( '/' ), $this->args['label_home'] );
 
 		if ( is_home() ) { // Static blog page.
-			$this->current = single_post_title( '', false ) ?? '';
+			$this->current = single_post_title( '', false );
 		} elseif ( is_post_type_archive() ) {
-			$this->current = post_type_archive_title( '', false ) ?? '';
+			$this->current = post_type_archive_title( '', false );
 
 			// Post type archive can be used as the search results page (like in WooCommerce).
 			// In that case, we need to show both the post type archive title and the search results.
@@ -137,7 +137,7 @@ class Breadcrumbs {
 
 				$this->add_term_ancestors( $term );
 			}
-			$this->current = single_term_title( '', false ) ?? '';
+			$this->current = single_term_title( '', false );
 		} elseif ( is_search() ) {
 			$this->current = sprintf( $this->args['label_search'], get_search_query() );
 		} elseif ( is_404() ) {

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -115,9 +115,9 @@ class Breadcrumbs {
 		$this->add_link( home_url( '/' ), $this->args['label_home'] );
 
 		if ( is_home() ) { // Static blog page.
-			$this->current = single_post_title( '', false );
+			$this->current = single_post_title( '', false ) ?? '';
 		} elseif ( is_post_type_archive() ) {
-			$this->current = post_type_archive_title( '', false );
+			$this->current = post_type_archive_title( '', false ) ?? '';
 
 			// Post type archive can be used as the search results page (like in WooCommerce).
 			// In that case, we need to show both the post type archive title and the search results.
@@ -137,7 +137,7 @@ class Breadcrumbs {
 
 				$this->add_term_ancestors( $term );
 			}
-			$this->current = single_term_title( '', false );
+			$this->current = single_term_title( '', false ) ?? '';
 		} elseif ( is_search() ) {
 			$this->current = sprintf( $this->args['label_search'], get_search_query() );
 		} elseif ( is_404() ) {


### PR DESCRIPTION
https://app.asana.com/0/1200179452020411/1209218973347590
https://helpdesk.elightup.com/conversation/10182?folder_id=7

Lỗi này là hàm **get_current_page()** trả về string nhưng 1 số **curent_page** có thể trả về false.

version 4.2.2 có thêm ở file /slim-seo/src/Schema/Types/BreadcrumbList.php
```
$current_page = $this->source->get_current_page();
		if ( $current_page ) {
			$list[] = [
				'@type'    => 'ListItem',
				'position' => $position,
				'name'     => $current_page,
			];
		}
```
code này truy cập hàm get_current_page(), mà hàm này ở surecart  ( dùng instant checkout ) thì bị trả về null.
