### PR TITLE
Make Rest API works with dynamic variables

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -44,7 +44,7 @@ class Container {
 		$services['redirection'] = new Redirection\Loader;
 		$services['breadcrumbs'] = new Breadcrumbs;
 
-		$services['rest_api'] = new RestApi;
+		$services['rest_api'] = new RestApi( $services['meta_title'], $services['meta_description'] );
 
 		$services['no_category_base'] = new NoCategoryBase;
 

--- a/src/MetaTags/AdminColumns/Post.php
+++ b/src/MetaTags/AdminColumns/Post.php
@@ -2,7 +2,6 @@
 namespace SlimSEO\MetaTags\AdminColumns;
 
 use SlimSEO\Helpers\UI;
-use SlimSEO\MetaTags\Helper;
 
 class Post extends Base {
 	protected $object_type = 'post';
@@ -21,19 +20,15 @@ class Post extends Base {
 	 * The value of meta tags will be applied with filters to make them work in the back end.
 	 */
 	public function render( $column, $post_id ): void {
-		$data = get_post_meta( $post_id, 'slim_seo', true ) ?: [];
+		$post_id = (int) $post_id;
 
 		switch ( $column ) {
 			case 'meta_title':
-				$title = $data['title'] ?? '';
-				$title = (string) apply_filters( 'slim_seo_meta_title', $title, $post_id );
-				$title = Helper::render( $title, (int) $post_id );
+				$title = $this->title->get_rendered_singular_value( $post_id );
 				UI::tooltip( $title, "<span class='ss-meta-content'>$title</span>", 'top' );
 				break;
 			case 'meta_description':
-				$description = $data['description'] ?? '';
-				$description = (string) apply_filters( 'slim_seo_meta_description', $description, $post_id );
-				$description = Helper::render( $description, (int) $post_id );
+				$description = $this->description->get_rendered_singular_value( $post_id );
 				UI::tooltip( $description, "<span class='ss-meta-content'>$description</span>", 'top' );
 				break;
 			case 'index':

--- a/src/MetaTags/AdminColumns/Term.php
+++ b/src/MetaTags/AdminColumns/Term.php
@@ -21,20 +21,16 @@ class Term extends Base {
 	 * The value of meta tags will be applied with filters to make them work in the back end.
 	 */
 	public function render( $output, $column, $term_id ) {
-		$data = get_term_meta( $term_id, 'slim_seo', true ) ?: [];
+		$term_id = (int) $term_id;
 
 		switch ( $column ) {
 			case 'meta_title':
-				$title = $data['title'] ?? '';
-				$title = (string) apply_filters( 'slim_seo_meta_title', $title, $term_id );
-				$title = Helper::render( $title, 0, (int) $term_id );
+				$title = $this->title->get_rendered_term_value( $term_id );
 				ob_start();
 				UI::tooltip( $title, "<span class='ss-meta-content'>$title</span>", 'top' );
 				return ob_get_clean();
 			case 'meta_description':
-				$description = $data['description'] ?? '';
-				$description = (string) apply_filters( 'slim_seo_meta_description', $description, $term_id );
-				$description = Helper::render( $description, 0, (int) $term_id );
+				$description = $this->description->get_rendered_term_value( $term_id );
 				ob_start();
 				UI::tooltip( $description, "<span class='ss-meta-content'>$description</span>", 'top' );
 				return ob_get_clean();

--- a/src/MetaTags/AdminColumns/Term.php
+++ b/src/MetaTags/AdminColumns/Term.php
@@ -1,6 +1,7 @@
 <?php
 namespace SlimSEO\MetaTags\AdminColumns;
 
+use SlimSEO\Helpers\UI;
 use SlimSEO\MetaTags\Helper;
 
 class Term extends Base {
@@ -20,18 +21,23 @@ class Term extends Base {
 	 * The value of meta tags will be applied with filters to make them work in the back end.
 	 */
 	public function render( $output, $column, $term_id ) {
+		$data = get_term_meta( $term_id, 'slim_seo', true ) ?: [];
+
 		switch ( $column ) {
 			case 'meta_title':
-				$title = $this->title->get_term_value( $term_id );
-				$title = apply_filters( 'slim_seo_meta_title', $title, $term_id );
-				$title = Helper::normalize( $title );
-				return $title;
+				$title = $data['title'] ?? '';
+				$title = (string) apply_filters( 'slim_seo_meta_title', $title, $term_id );
+				$title = Helper::render( $title, 0, (int) $term_id );
+				ob_start();
+				UI::tooltip( $title, "<span class='ss-meta-content'>$title</span>", 'top' );
+				return ob_get_clean();
 			case 'meta_description':
-				$data        = get_term_meta( $term_id, 'slim_seo', true ) ?: [];
 				$description = $data['description'] ?? '';
-				$description = apply_filters( 'slim_seo_meta_description', $description, $term_id );
-				$description = Helper::normalize( $description );
-				return $description;
+				$description = (string) apply_filters( 'slim_seo_meta_description', $description, $term_id );
+				$description = Helper::render( $description, 0, (int) $term_id );
+				ob_start();
+				UI::tooltip( $description, "<span class='ss-meta-content'>$description</span>", 'top' );
+				return ob_get_clean();
 			case 'index':
 				$noindex = $this->robots->get_term_value( $term_id );
 				$index   = apply_filters( 'slim_seo_robots_index', ! $noindex, $term_id );

--- a/src/MetaTags/AdminColumns/Term.php
+++ b/src/MetaTags/AdminColumns/Term.php
@@ -2,7 +2,6 @@
 namespace SlimSEO\MetaTags\AdminColumns;
 
 use SlimSEO\Helpers\UI;
-use SlimSEO\MetaTags\Helper;
 
 class Term extends Base {
 	protected $object_type = 'term';

--- a/src/MetaTags/Description.php
+++ b/src/MetaTags/Description.php
@@ -53,20 +53,12 @@ class Description {
 		return Option::get( "{$post_type_object->name}_archive.description", self::DEFAULTS['post_archive'] );
 	}
 
-	/**
-	 * Get custom meta description or fallback to post excerpt or post content
-	 * Make public to allow access from other class. See Integration/WooCommerce.
-	 */
-	public function get_singular_value( $post_id = null ): string {
+	private function get_singular_value( int $post_id = 0 ): string {
 		$post_id = $post_id ?: $this->get_queried_object_id();
-		$post    = get_post( $post_id );
-		if ( ! $post ) {
-			return '';
-		}
 
 		// Prevent showing description on password protected posts
-		if ( post_password_required( $post ) ) {
-			return __( 'There is no excerpt because this is a protected post.', 'slim-seo' );
+		if ( post_password_required( $post_id ) ) {
+			return '';
 		}
 
 		// Use manual entered meta description if available.

--- a/src/MetaTags/Description.php
+++ b/src/MetaTags/Description.php
@@ -73,6 +73,20 @@ class Description {
 		return Option::get( "$post_type.description", '{{ post.auto_description }}' );
 	}
 
+	/**
+	 * Get the rendered meta description, after parsing dynamic variables
+	 * Make public to allow access from other class.
+	 * @see \SlimSEO\MetaTags\AdminColumns\Post::render()
+	 * @see \SlimSEO\RestApi::prepare_value_for_post()
+	 */
+	public function get_rendered_singular_value( int $post_id = 0 ): string {
+		$description = $this->get_singular_value( $post_id );
+		$description = (string) apply_filters( 'slim_seo_meta_description', $description, $post_id );
+		$description = Helper::render( $description, $post_id );
+
+		return $description;
+	}
+
 	public function get_term_value( $term_id = null ): string {
 		$term_id = $term_id ?: $this->get_queried_object_id();
 		$data    = get_term_meta( $term_id, 'slim_seo', true );
@@ -87,6 +101,19 @@ class Description {
 
 		// Use taxonomy settings if avaiable, then fallback to the term auto description
 		return Option::get( "{$term->taxonomy}.description", '{{ term.auto_description }}' );
+	}
+
+	/**
+	 * Get the rendered meta description, after parsing dynamic variables
+	 * Make public to allow access from other class.
+	 * @see \SlimSEO\MetaTags\AdminColumns\Term::render()
+	 */
+	public function get_rendered_term_value( int $term_id = 0 ): string {
+		$description = $this->get_term_value( $term_id );
+		$description = (string) apply_filters( 'slim_seo_meta_description', $description, $term_id );
+		$description = Helper::render( $description, 0, $term_id );
+
+		return $description;
 	}
 
 	private function get_author_value(): string {

--- a/src/MetaTags/Description.php
+++ b/src/MetaTags/Description.php
@@ -9,6 +9,14 @@ use SlimSEO\Helpers\Option;
 class Description {
 	use Context;
 
+	const DEFAULTS = [
+		'home'         => '{{ site.description }}',
+		'post'         => '{{ post.auto_description }}',
+		'post_archive' => '',
+		'term'         => '{{ term.auto_description }}',
+		'author'       => '{{ author.auto_description }}',
+	];
+
 	public function setup() {
 		$this->add_excerpt_to_pages();
 		add_action( 'slim_seo_head', [ $this, 'output' ] );
@@ -37,12 +45,12 @@ class Description {
 	}
 
 	private function get_home_value(): string {
-		return Option::get( 'home.description', '{{ site.description }}' );
+		return Option::get( 'home.description', self::DEFAULTS['home'] );
 	}
 
 	private function get_post_type_archive_value(): string {
 		$post_type_object = get_queried_object();
-		return Option::get( "{$post_type_object->name}_archive.description", '' );
+		return Option::get( "{$post_type_object->name}_archive.description", self::DEFAULTS['post_archive'] );
 	}
 
 	/**
@@ -70,7 +78,7 @@ class Description {
 		$post_type = get_post_type( $post_id );
 
 		// Use post type settings if avaiable, then fallback to the post auto description
-		return Option::get( "$post_type.description", '{{ post.auto_description }}' );
+		return Option::get( "$post_type.description", self::DEFAULTS['post'] );
 	}
 
 	/**
@@ -100,7 +108,7 @@ class Description {
 		}
 
 		// Use taxonomy settings if avaiable, then fallback to the term auto description
-		return Option::get( "{$term->taxonomy}.description", '{{ term.auto_description }}' );
+		return Option::get( "{$term->taxonomy}.description", self::DEFAULTS['term'] );
 	}
 
 	/**
@@ -118,6 +126,6 @@ class Description {
 
 	private function get_author_value(): string {
 		// Use author settings if avaiable, then fallback to the author auto description
-		return Option::get( 'author.description', '{{ author.auto_description }}' );
+		return Option::get( 'author.description', self::DEFAULTS['author'] );
 	}
 }

--- a/src/MetaTags/Description.php
+++ b/src/MetaTags/Description.php
@@ -17,7 +17,7 @@ class Description {
 		'author'       => '{{ author.auto_description }}',
 	];
 
-	public function setup() {
+	public function setup(): void {
 		$this->add_excerpt_to_pages();
 		add_action( 'slim_seo_head', [ $this, 'output' ] );
 	}
@@ -25,11 +25,11 @@ class Description {
 	/**
 	 * Add excerpt to pages to let users customize meta description.
 	 */
-	public function add_excerpt_to_pages() {
+	public function add_excerpt_to_pages(): void {
 		add_post_type_support( 'page', 'excerpt' );
 	}
 
-	public function output() {
+	public function output(): void {
 		$description = $this->get_description();
 		if ( $description ) {
 			echo '<meta name="description" content="', esc_attr( $description ), '">', "\n";

--- a/src/MetaTags/Settings/Preview.php
+++ b/src/MetaTags/Settings/Preview.php
@@ -6,6 +6,7 @@ use WP_REST_Request;
 use WP_Term;
 use SlimSEO\Helpers\Option;
 use SlimSEO\MetaTags\Helper;
+use SlimSEO\MetaTags\Title;
 
 class Preview {
 	public function setup(): void {
@@ -96,17 +97,17 @@ class Preview {
 		// For static frontpage: don't use page's settings, use WordPress default instead.
 		$is_static_frontpage = 'page' === get_option( 'show_on_front' ) && $post_id === (int) get_option( 'page_on_front' );
 		if ( $is_static_frontpage ) {
-			return '{{ site.title }} {{ sep }} {{ site.description }}';
+			return Title::DEFAULTS['home'];
 		}
 
-		$default = '{{ post.title }} {{ page }} {{ sep }} {{ site.title }}';
+		$default = Title::DEFAULTS['post'];
 		$key     = get_post_type( $post_id );
 
 		return $key ? Option::get( "$key.title", $default ) : $default;
 	}
 
 	private function get_default_term_title( int $term_id ): string {
-		$default = '{{ term.name }} {{ page }} {{ sep }} {{ site.title }}';
+		$default = Title::DEFAULTS['term'];
 		$term    = get_term( $term_id );
 		if ( ! ( $term instanceof WP_Term ) ) {
 			return $default;

--- a/src/MetaTags/Settings/Preview.php
+++ b/src/MetaTags/Settings/Preview.php
@@ -6,6 +6,7 @@ use WP_REST_Request;
 use WP_Term;
 use SlimSEO\Helpers\Option;
 use SlimSEO\MetaTags\Helper;
+use SlimSEO\MetaTags\Description;
 use SlimSEO\MetaTags\Title;
 
 class Preview {
@@ -140,7 +141,7 @@ class Preview {
 	}
 
 	private function get_default_term_description( int $term_id ): string {
-		$default = '{{ term.auto_description }}';
+		$default = Description::DEFAULTS['term'];
 		$term    = get_term( $term_id );
 		if ( ! ( $term instanceof WP_Term ) ) {
 			return $default;
@@ -177,7 +178,7 @@ class Preview {
 	}
 
 	private function get_default_post_description( int $post_id ): string {
-		$default = '{{ post.auto_description }}';
+		$default = Description::DEFAULTS['post'];
 		$key     = get_post_type( $post_id );
 
 		return $key ? Option::get( "$key.description", $default ) : $default;

--- a/src/MetaTags/Title.php
+++ b/src/MetaTags/Title.php
@@ -62,6 +62,20 @@ class Title {
 	}
 
 	/**
+	 * Get the rendered meta title, after parsing dynamic variables
+	 * Make public to allow access from other class.
+	 * @see \SlimSEO\MetaTags\AdminColumns\Post::render()
+	 * @see \SlimSEO\RestApi::prepare_value_for_post()
+	 */
+	public function get_rendered_singular_value( int $post_id = 0 ): string {
+		$title = $this->get_singular_value( $post_id ) ?: '{{ post.title }} {{ page }} {{ sep }} {{ site.title }}';
+		$title = (string) apply_filters( 'slim_seo_meta_title', $title, $post_id );
+		$title = Helper::render( $title, $post_id );
+
+		return $title;
+	}
+
+	/**
 	 * Make public to allow access from other class.
 	 * @see AdminColumns/Term.php.
 	 */
@@ -78,6 +92,19 @@ class Title {
 		}
 
 		return Option::get( "{$term->taxonomy}.title", '' );
+	}
+
+	/**
+	 * Get the rendered meta title, after parsing dynamic variables
+	 * Make public to allow access from other class.
+	 * @see \SlimSEO\MetaTags\AdminColumns\Term::render()
+	 */
+	public function get_rendered_term_value( int $term_id = 0 ): string {
+		$title = $this->get_term_value( $term_id ) ?: '{{ term.name }} {{ page }} {{ sep }} {{ site.title }}';
+		$title = (string) apply_filters( 'slim_seo_meta_title', $title, $term_id );
+		$title = Helper::render( $title, 0, $term_id );
+
+		return $title;
 	}
 
 	public function set_page_title_as_archive_title( string $title ): string {

--- a/src/MetaTags/Title.php
+++ b/src/MetaTags/Title.php
@@ -9,7 +9,15 @@ use SlimSEO\Helpers\Option;
 class Title {
 	use Context;
 
-	public function setup() {
+	const DEFAULTS = [
+		'home'         => '{{ site.title }} {{ sep }} {{ site.description }}',
+		'post'         => '{{ post.title }} {{ page }} {{ sep }} {{ site.title }}',
+		'post_archive' => '{{ post_type.labels.plural }} {{ page }} {{ sep }} {{ site.title }}',
+		'term'         => '{{ term.name }} {{ page }} {{ sep }} {{ site.title }}',
+		'author'       => '{{ author.display_name }} {{ page }} {{ sep }} {{ site.title }}',
+	];
+
+	public function setup(): void {
 		add_theme_support( 'title-tag' );
 		add_filter( 'pre_get_document_title', [ $this, 'filter_title' ] );
 
@@ -68,7 +76,7 @@ class Title {
 	 * @see \SlimSEO\RestApi::prepare_value_for_post()
 	 */
 	public function get_rendered_singular_value( int $post_id = 0 ): string {
-		$title = $this->get_singular_value( $post_id ) ?: '{{ post.title }} {{ page }} {{ sep }} {{ site.title }}';
+		$title = $this->get_singular_value( $post_id ) ?: self::DEFAULTS['post'];
 		$title = (string) apply_filters( 'slim_seo_meta_title', $title, $post_id );
 		$title = Helper::render( $title, $post_id );
 
@@ -100,7 +108,7 @@ class Title {
 	 * @see \SlimSEO\MetaTags\AdminColumns\Term::render()
 	 */
 	public function get_rendered_term_value( int $term_id = 0 ): string {
-		$title = $this->get_term_value( $term_id ) ?: '{{ term.name }} {{ page }} {{ sep }} {{ site.title }}';
+		$title = $this->get_term_value( $term_id ) ?: self::DEFAULTS['term'];
 		$title = (string) apply_filters( 'slim_seo_meta_title', $title, $term_id );
 		$title = Helper::render( $title, 0, $term_id );
 

--- a/src/MetaTags/Title.php
+++ b/src/MetaTags/Title.php
@@ -47,12 +47,11 @@ class Title {
 	}
 
 	/**
-	 * Make public to allow access from other class.
+	 * Get singular post/page/post type meta title.
 	 * Note that returning empty string will use WordPress default title.
-	 * @see AdminColumns/Post.php.
 	 */
-	public function get_singular_value( $post_id = 0 ): string {
-		$post_id = (int) ( $post_id ?: $this->get_queried_object_id() );
+	private function get_singular_value( int $post_id = 0 ): string {
+		$post_id = $post_id ?: $this->get_queried_object_id();
 		$data    = get_post_meta( $post_id, 'slim_seo', true );
 		if ( ! empty( $data['title'] ) ) {
 			return $data['title'];

--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -49,9 +49,14 @@ class RestApi {
 	}
 
 	public function prepare_value_for_post( $value, WP_REST_Request $request, array $args ): array {
+		$post = get_post();
+		if ( ! $post ) {
+			return [];
+		}
+
 		$parsed_value = [
-			'title'       => $this->get_post_meta_title(),
-			'description' => $this->get_post_meta_description(),
+			'title'       => $this->title->get_rendered_singular_value( $post->ID ),
+			'description' => $this->description->get_rendered_singular_value( $post->ID ),
 		];
 		$value = array_merge( (array) $value, $parsed_value );
 
@@ -67,32 +72,5 @@ class RestApi {
 		$value = array_map( [ Helper::class, 'render' ], $value );
 
 		return $value;
-	}
-
-	private function get_post_meta_title(): string {
-		$post = get_post();
-		if ( empty( $post ) ) {
-			return '';
-		}
-
-		$title = $this->title->get_singular_value( $post->ID );
-		$title = $title ?: '{{ post.title }} {{ page }} {{ sep }} {{ site.title }}';
-		$title = (string) apply_filters( 'slim_seo_meta_title', $title, $post->ID );
-		$title = Helper::render( $title, $post->ID );
-
-		return $title;
-	}
-
-	private function get_post_meta_description(): string {
-		$post = get_post();
-		if ( empty( $post ) ) {
-			return '';
-		}
-
-		$description = $this->description->get_singular_value( $post->ID );
-		$description = (string) apply_filters( 'slim_seo_meta_description', $description, $post->ID );
-		$description = Helper::render( $description, $post->ID );
-
-		return $description;
 	}
 }

--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -55,20 +55,11 @@ class RestApi {
 		];
 		$value = array_merge( (array) $value, $parsed_value );
 
-		return $this->prepare_value( $value, $request, $args );
+		// Let WordPress prepare the value first. It will auto format the value as defined in the schema.
+		return WP_REST_Meta_Fields::prepare_value( $value, $request, $args );
 	}
 
 	public function prepare_value_for_term( $value, WP_REST_Request $request, array $args ): array {
-		$defaults = [
-			'title'       => $this->title->get_term_value(),
-			'description' => $this->description->get_term_value(),
-		];
-		$value = array_merge( $defaults, (array) $value );
-
-		return $this->prepare_value( $value, $request, $args );
-	}
-
-	private function prepare_value( $value, WP_REST_Request $request, array $args ): array {
 		// Let WordPress prepare the value first. It will auto format the value as defined in the schema.
 		$value = WP_REST_Meta_Fields::prepare_value( $value, $request, $args );
 

--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -1,16 +1,26 @@
 <?php
 namespace SlimSEO;
 
+use SlimSEO\MetaTags\Title;
+use SlimSEO\MetaTags\Description;
 use SlimSEO\MetaTags\Helper;
 use WP_REST_Meta_Fields;
 use WP_REST_Request;
 
 class RestApi {
-	public function setup() {
+	private $title;
+	private $description;
+
+	public function __construct( Title $title, Description $description ) {
+		$this->title       = $title;
+		$this->description = $description;
+	}
+
+	public function setup(): void {
 		add_action( 'rest_api_init', [ $this, 'register_meta' ] );
 	}
 
-	public function register_meta() {
+	public function register_meta(): void {
 		$args = [
 			'type'         => 'object',
 			'description'  => __( 'Search Engine Optimization', 'slim-seo' ),
@@ -27,15 +37,38 @@ class RestApi {
 						'noindex'        => [ 'type' => 'boolean' ],
 					],
 				],
-				'prepare_callback' => [ $this, 'prepare_value' ],
 			],
 		];
 
-		register_meta( 'post', 'slim_seo', $args );
-		register_meta( 'term', 'slim_seo', $args );
+		$args_post = $args_term = $args;
+		$args_post['show_in_rest']['prepare_callback'] = [ $this, 'prepare_value_for_post' ];
+		$args_term['show_in_rest']['prepare_callback'] = [ $this, 'prepare_value_for_term' ];
+
+		register_meta( 'post', 'slim_seo', $args_post );
+		register_meta( 'term', 'slim_seo', $args_term );
 	}
 
-	public function prepare_value( $value, WP_REST_Request $request, array $args ): array {
+	public function prepare_value_for_post( $value, WP_REST_Request $request, array $args ): array {
+		$parsed_value = [
+			'title'       => $this->get_post_meta_title(),
+			'description' => $this->get_post_meta_description(),
+		];
+		$value = array_merge( (array) $value, $parsed_value );
+
+		return $this->prepare_value( $value, $request, $args );
+	}
+
+	public function prepare_value_for_term( $value, WP_REST_Request $request, array $args ): array {
+		$defaults = [
+			'title'       => $this->title->get_term_value(),
+			'description' => $this->description->get_term_value(),
+		];
+		$value = array_merge( $defaults, (array) $value );
+
+		return $this->prepare_value( $value, $request, $args );
+	}
+
+	private function prepare_value( $value, WP_REST_Request $request, array $args ): array {
 		// Let WordPress prepare the value first. It will auto format the value as defined in the schema.
 		$value = WP_REST_Meta_Fields::prepare_value( $value, $request, $args );
 
@@ -43,5 +76,32 @@ class RestApi {
 		$value = array_map( [ Helper::class, 'render' ], $value );
 
 		return $value;
+	}
+
+	private function get_post_meta_title(): string {
+		$post = get_post();
+		if ( empty( $post ) ) {
+			return '';
+		}
+
+		$title = $this->title->get_singular_value( $post->ID );
+		$title = $title ?: '{{ post.title }} {{ page }} {{ sep }} {{ site.title }}';
+		$title = (string) apply_filters( 'slim_seo_meta_title', $title, $post->ID );
+		$title = Helper::render( $title, $post->ID );
+
+		return $title;
+	}
+
+	private function get_post_meta_description(): string {
+		$post = get_post();
+		if ( empty( $post ) ) {
+			return '';
+		}
+
+		$description = $this->description->get_singular_value( $post->ID );
+		$description = (string) apply_filters( 'slim_seo_meta_description', $description, $post->ID );
+		$description = Helper::render( $description, $post->ID );
+
+		return $description;
 	}
 }

--- a/src/Settings/MetaTags/Manager.php
+++ b/src/Settings/MetaTags/Manager.php
@@ -3,6 +3,7 @@ namespace SlimSEO\Settings\MetaTags;
 
 use SlimSEO\Helpers\Assets;
 use SlimSEO\Helpers\Data;
+use SlimSEO\MetaTags\Description;
 use SlimSEO\MetaTags\Title;
 
 class Manager {
@@ -40,7 +41,7 @@ class Manager {
 			'link'        => get_home_url(),
 			'name'        => get_the_title( get_option( 'page_on_front' ) ),
 			'title'       => Title::DEFAULTS['home'],
-			'description' => '{{ site.description }}',
+			'description' => Description::DEFAULTS['home'],
 			'edit'        => get_edit_post_link( get_option( 'page_on_front' ) ),
 		] );
 	}
@@ -118,11 +119,11 @@ class Manager {
 		return [
 			'single'  => [
 				'title'       => Title::DEFAULTS['post'],
-				'description' => '{{ post.auto_description }}',
+				'description' => Description::DEFAULTS['post'],
 			],
 			'archive' => [
 				'title'       => Title::DEFAULTS['post_archive'],
-				'description' => '',
+				'description' => Description::DEFAULTS['post_archive'],
 			],
 		];
 	}
@@ -130,14 +131,14 @@ class Manager {
 	private function get_default_term_metas(): array {
 		return [
 			'title'       => Title::DEFAULTS['term'],
-			'description' => '{{ term.auto_description }}',
+			'description' => Description::DEFAULTS['term'],
 		];
 	}
 
 	private function get_default_author_metas(): array {
 		return [
 			'title'       => Title::DEFAULTS['author'],
-			'description' => '{{ author.auto_description }}',
+			'description' => Description::DEFAULTS['author'],
 		];
 	}
 }

--- a/src/Settings/MetaTags/Manager.php
+++ b/src/Settings/MetaTags/Manager.php
@@ -3,6 +3,7 @@ namespace SlimSEO\Settings\MetaTags;
 
 use SlimSEO\Helpers\Assets;
 use SlimSEO\Helpers\Data;
+use SlimSEO\MetaTags\Title;
 
 class Manager {
 	private $defaults = [
@@ -38,7 +39,7 @@ class Manager {
 		return array_merge( $this->defaults, [
 			'link'        => get_home_url(),
 			'name'        => get_the_title( get_option( 'page_on_front' ) ),
-			'title'       => '{{ site.title }} {{ sep }} {{ site.description }}',
+			'title'       => Title::DEFAULTS['home'],
 			'description' => '{{ site.description }}',
 			'edit'        => get_edit_post_link( get_option( 'page_on_front' ) ),
 		] );
@@ -116,11 +117,11 @@ class Manager {
 	private function get_default_post_metas(): array {
 		return [
 			'single'  => [
-				'title'       => '{{ post.title }} {{ page }} {{ sep }} {{ site.title }}',
+				'title'       => Title::DEFAULTS['post'],
 				'description' => '{{ post.auto_description }}',
 			],
 			'archive' => [
-				'title'       => '{{ post_type.labels.plural }} {{ page }} {{ sep }} {{ site.title }}',
+				'title'       => Title::DEFAULTS['post_archive'],
 				'description' => '',
 			],
 		];
@@ -128,14 +129,14 @@ class Manager {
 
 	private function get_default_term_metas(): array {
 		return [
-			'title'       => '{{ term.name }} {{ page }} {{ sep }} {{ site.title }}',
+			'title'       => Title::DEFAULTS['term'],
 			'description' => '{{ term.auto_description }}',
 		];
 	}
 
 	private function get_default_author_metas(): array {
 		return [
-			'title'       => '{{ author.display_name }} {{ page }} {{ sep }} {{ site.title }}',
+			'title'       => Title::DEFAULTS['author'],
 			'description' => '{{ author.auto_description }}',
 		];
 	}


### PR DESCRIPTION
Also improve meta title & description code base with: 

- Defaults (const)
- Public methods to get rendered values, which are used for the Rest API and admin columns

This PR also makes admin columns always display rendered values even if no custom meta tags. This makes sense since dynamic variables can be used to configured the meta tags not as default.