### PR TITLE
Fix breadcrumbs issues with Elementor

### DIFF
--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -226,6 +226,9 @@ class Breadcrumbs {
 		// Otherwise get from the post type archive settings.
 		$archive_page = Data::get_post_type_archive_page( $post_type );
 		if ( $archive_page ) {
+			if ( $archive_page->post_status !== 'publish' ) {
+				return;
+			}
 			$text = get_the_title( $archive_page );
 		}
 


### PR DESCRIPTION
Some WordPress functions like `get_queried_object()` returns `null` in some edge cases, which breaks the type hints in the breadcrumbs. This PR adds more checks to prevent this from happening.

Also, for post type archive page, if it's set to a static page, but not published, it won't show in the breadcrumbs.