### PR TITLE
Fix ignoring Woo pages affect other pages in admin post table

### DIFF
--- a/src/MetaTags/Data.php
+++ b/src/MetaTags/Data.php
@@ -39,7 +39,7 @@ class Data {
 		if ( empty( $post ) ) {
 			return [];
 		}
-		$post_content = apply_filters( 'slim_seo_post_content', $post->post_content, $post );
+		$post_content = self::get_post_content( $post->ID );
 
 		$post_tax   = [];
 		$taxonomies = Helper::get_taxonomies();
@@ -166,5 +166,28 @@ class Data {
 
 	private function normalize( $key ) {
 		return str_replace( '-', '_', $key );
+	}
+
+	/**
+	 * Get post content with filters for page builders to modify the content.
+	 * Also has a filter to skip the content for certain pages, like WooCommerce checkout, cart, account, etc.
+	 *
+	 * @param int $post_id Post ID.
+	 * @param string $content Optional. Custom post content, used for live preview when the new content is not saved yet.
+	 * @return string
+	 */
+	public static function get_post_content( int $post_id = 0, string $content = '' ): string {
+		if ( apply_filters( 'slim_seo_no_post_content', false, $post_id ) ) {
+			return '';
+		}
+
+		$post = get_post( $post_id );
+		if ( empty( $post ) ) {
+			return '';
+		}
+
+		$content = $content ?: $post->post_content;
+
+		return (string) apply_filters( 'slim_seo_post_content', $content, $post );
 	}
 }

--- a/src/MetaTags/Settings/Preview.php
+++ b/src/MetaTags/Settings/Preview.php
@@ -8,6 +8,7 @@ use SlimSEO\Helpers\Option;
 use SlimSEO\MetaTags\Helper;
 use SlimSEO\MetaTags\Description;
 use SlimSEO\MetaTags\Title;
+use SlimSEO\MetaTags\Data;
 
 class Preview {
 	public function setup(): void {
@@ -161,7 +162,7 @@ class Preview {
 		$text    = (string) $request->get_param( 'text' ); // Manual entered meta description
 		$excerpt = (string) $request->get_param( 'excerpt' ); // Live excerpt
 		$content = (string) $request->get_param( 'content' ); // Live content
-		$content = apply_filters( 'slim_seo_post_content', $content, get_post( $id ) );
+		$content = Data::get_post_content( $id, $content );
 
 		$data         = [];
 		$data['post'] = array_filter( [


### PR DESCRIPTION
The previous code remove all filters for slim_seo_post_content when detecting a Woo page. This makes all pages below the Cart/Checkout/My Account page in the post table list won't parse shortcodes for meta tags.

This PR fixes this issue by introducing a new filter to skip posts.