### PR TITLE
Bricks integration: fix rendering meta tags in the admin post list table

### DIFF
--- a/src/Integrations/Bricks.php
+++ b/src/Integrations/Bricks.php
@@ -28,9 +28,6 @@ class Bricks {
 		// Get from the post first, then from the template.
 		$data = get_post_meta( $post->ID, BRICKS_DB_PAGE_CONTENT, true );
 		if ( empty( $data ) ) {
-			$data = \Bricks\Helpers::get_bricks_data( $post->ID );
-		}
-		if ( empty( $data ) ) {
 			return null;
 		}
 

--- a/src/MetaTags/Helper.php
+++ b/src/MetaTags/Helper.php
@@ -91,9 +91,9 @@ class Helper {
 	private static function set_allowed_blocks(): void {
 		$block_types = WP_Block_Type_Registry::get_instance()->get_all_registered();
 
-		// Do not parse dynamic blocks.
+		// Do not parse dynamic blocks, except core/heading (which is dynamic!)
 		$block_types = array_filter( $block_types, function ( WP_Block_Type $block ): bool {
-			return ! $block->is_dynamic();
+			return $block->name === 'core/heading' || ! $block->is_dynamic();
 		} );
 
 		$block_names    = array_keys( $block_types );


### PR DESCRIPTION
Issue: Bricks doesn't render dynamic tags in the admin. So parsing it doesn't work.

This usually happens when using a template for posts.

To solve this problem completely, we should ignore parsing templates. Instead of that, always use the real post content (the content entered in the block/classic editor).

This PR also changes the way to exclude elements by filtering to "render" hook, which allows to run with nestable elements.