### PR TITLE
Bricks integration: fix slider in Bricks Extras, WPGB facet

### DIFF
--- a/src/Integrations/Bricks.php
+++ b/src/Integrations/Bricks.php
@@ -9,16 +9,13 @@ class Bricks {
 
 	private $skipped_elements = [
 		// Bricks.
-		'audio',
 		'code',
 		'divider',
 		'facebook-page',
 		'form',
 		'icon',
 		'image',
-		'image-gallery',
 		'map',
-		'nav-menu',
 		'pagination',
 		'pie-chart',
 		'post-author',
@@ -28,21 +25,13 @@ class Bricks {
 		'post-taxonomy',
 		'post-sharing',
 		'post-title',
-		'posts',
 		'related-posts',
-		'search',
-		'sidebar',
-		'shortcode',
 		'social-icons',
-		'svg',
 		'video',
-		'wordpress',
 
 		// Extra elements.
 		'wpgb-facet',
 		'jet-engine-listing-grid',
-		'xproslider',
-		'xproslidercontrol',
 		'happyfiles-gallery',
 	];
 
@@ -104,6 +93,13 @@ class Bricks {
 	}
 
 	private function should_render( $element ): bool {
+		$element_data = \Bricks\Elements::get_element( (array) $element );
+
+		// Ignore all elements in certain categories.
+		if ( in_array( Data::get( $element_data, 'category' ), [ 'media', 'query', 'wordpress', 'extras' ], true ) ) {
+			return false;
+		}
+
 		if ( in_array( Data::get( $element, 'name' ), $this->skipped_elements ) ) {
 			return false;
 		}
@@ -125,7 +121,7 @@ class Bricks {
 
 		// Remove elements with scripts, like sliders or counters, to avoid breaking layouts.
 		// Don't count 'bricksBackgroundVideoInit' as it's always enabled for nestable elements.
-		$scripts = (array) Data::get( $element, 'scripts', [] );
+		$scripts = (array) Data::get( $element_data, 'scripts', [] );
 		$scripts = array_diff( $scripts, [ 'bricksBackgroundVideoInit' ] );
 		if ( ! empty( $scripts ) ) {
 			return false;


### PR DESCRIPTION
There are 2 ways to eliminate an element from rendering:

- Remove it completely from `$data`, which is the previous way to handle the compatibility. However, it doesn't handle well with nested elements. Hence, the 2nd way:
- Filtering to `bricks/element/render`, which decides whether to render an element. But it doesn't handle enqueuing scripts!

This PR uses both ways to fix the issue. And also improve by ignoring elements by category: 'media', 'query', 'wordpress', 'extras' (from Bricks Extras).