### PR TITLE
Prevent XSS vulnerability in schema output

### DIFF
--- a/src/Schema/Manager.php
+++ b/src/Schema/Manager.php
@@ -48,9 +48,13 @@ class Manager {
 		// Do not encode HTML entities (&, <, >, ', ")
 		// which are auto encoded by WordPress functions (get_bloginfo(), wp_get_document_title(), etc.
 		$graph = map_deep( $graph, function ( $value ) {
-			return is_string( $value )
-				? html_entity_decode( $value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, 'UTF-8' )
-				: $value;
+			if ( ! is_string( $value ) ) {
+				return $value;
+			}
+
+			$value = html_entity_decode( $value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, 'UTF-8' );
+
+			return wp_strip_all_tags( $value );
 		} );
 
 		$schema = [


### PR DESCRIPTION
Schema output ko nên chứa HTML tags, ví dụ user nhập domain/?s=<script>alert('a')</script> thì trong Schema (BreadcrumbList) sẽ output như sau: Search Results for “<script>alert('a')</script>”.






