### PR TITLE
Simplify social image fallback to featured image only

### DIFF
--- a/js/meta-tags/Single.js
+++ b/js/meta-tags/Single.js
@@ -39,7 +39,7 @@ const Post = ( { features } ) => (
 			<FacebookImage
 				id="slim_seo[facebook_image]"
 				std={ ss.data.facebook_image }
-				description={ __( 'Leave empty to use the featured image or the first image in the post content.', 'slim-seo' ) }
+				description={ __( 'Leave empty to use the featured image.', 'slim-seo' ) }
 			/>
 		}
 		{
@@ -47,7 +47,7 @@ const Post = ( { features } ) => (
 			<TwitterImage
 				id="slim_seo[twitter_image]"
 				std={ ss.data.twitter_image }
-				description={ __( 'Leave empty to use the featured image or the first image in the post content.', 'slim-seo' ) }
+				description={ __( 'Leave empty to use the featured image.', 'slim-seo' ) }
 			/>
 		}
 		<Text id="slim_seo[canonical]" label={ __( 'Canonical URL', 'slim-seo' ) } std={ ss.data.canonical } />

--- a/js/meta-tags/components/PostType.js
+++ b/js/meta-tags/components/PostType.js
@@ -26,8 +26,8 @@ const PostType = ( { id, postType, option, optionArchive, social } ) => {
 				label={ sprintf( __( 'Singular %s', 'slim-seo' ), postType.labels.singular_name.toLowerCase() ) }
 				defaultMetas={ ss.defaultPostMetas.single }
 				social={ social }
-				facebookImageInstruction={ __( 'Leave empty to use the featured image or the first image in the post content.', 'slim-seo' ) }
-				twitterImageInstruction={ __( 'Leave empty to use the featured image or the first image in the post content.', 'slim-seo' ) }
+				facebookImageInstruction={ __( 'Leave empty to use the featured image.', 'slim-seo' ) }
+				twitterImageInstruction={ __( 'Leave empty to use the featured image.', 'slim-seo' ) }
 			/>
 		}
 		{ !noindex &&

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  '@parcel/watcher': true
+  core-js: true
+  core-js-pure: true

--- a/src/MetaTags/Image.php
+++ b/src/MetaTags/Image.php
@@ -4,6 +4,7 @@ namespace SlimSEO\MetaTags;
 defined( 'ABSPATH' ) || die;
 
 use WP_Term;
+use WP_Post;
 use SlimSEO\Helpers\Images;
 use SlimSEO\Helpers\Option;
 
@@ -37,22 +38,15 @@ class Image {
 		// Get from settings.
 		$option = get_option( 'slim_seo', [] );
 		$post   = $this->get_queried_object();
-		if ( empty( $post ) ) {
+		if ( ! ( $post instanceof WP_Post ) ) {
 			return [];
 		}
 		if ( isset( $option[ $post->post_type ][ $this->meta_key ] ) ) {
 			return $this->get_from_settings( $option[ $post->post_type ][ $this->meta_key ] );
 		}
 
-		// Get from thumbnail or content.
-		$images = Images::get_post_images( $this->get_queried_object() );
-		if ( empty( $images ) ) {
-			return [];
-		}
-
-		$first_image = reset( $images );
-		$method      = is_numeric( $first_image ) ? 'get_data' : 'get_data_from_url';
-		return $this->$method( $first_image );
+		// Get from thumbnail.
+		return has_post_thumbnail() ? $this->get_data( get_post_thumbnail_id() ) : [];
 	}
 
 	private function get_term_value(): array {

--- a/src/MetaTags/OpenGraph.php
+++ b/src/MetaTags/OpenGraph.php
@@ -76,8 +76,11 @@ class OpenGraph {
 		return $this->get_image_attribute( 'alt' );
 	}
 
-	private function get_image_attribute( $key ) {
-		$image = $this->image_obj->get_value() ?: $this->get_default_image();
+	private function get_image_attribute( string $key ) {
+		static $image = null;
+		if ( $image === null ) {
+			$image = $this->image_obj->get_value() ?: $this->get_default_image();
+		}
 		return $image[ $key ] ?? null;
 	}
 


### PR DESCRIPTION
## Summary

- Remove fallback to first image in post content for OG/Twitter images — now only uses the featured image
- Add static cache to `OpenGraph::get_image_attribute()` to avoid redundant image resolution across 4 attribute lookups
- Improve type check from `empty($post)` to `instanceof WP_Post` to correctly reject `WP_Term` objects on taxonomy archives
- Update UI descriptions to match new behavior

## Changes

| File | Change |
|------|--------|
| `src/MetaTags/Image.php` | Removed `Images::get_post_images()` fallback, now uses `get_post_thumbnail_id()` only |
| `src/MetaTags/OpenGraph.php` | Added static cache + `string` type hint to `get_image_attribute()` |
| `js/meta-tags/Single.js` | Updated helper text to "Leave empty to use the featured image." |
| `js/meta-tags/components/PostType.js` | Same helper text update for custom post types |
| `pnpm-workspace.yaml` | Allow builds for `@parcel/watcher`, `core-js`, `core-js-pure` |