### PR TITLE
Add deleted URL notifications for redirection

### DIFF
--- a/js/redirection/deleted-url-notification.js
+++ b/js/redirection/deleted-url-notification.js
@@ -1,0 +1,15 @@
+document.addEventListener( 'click', ( { target } ) => {
+	const notice = target.closest( '.ss-redirection-deleted-url-notification' );
+
+	if ( target.classList.contains( 'notice-dismiss' ) && notice ) {
+		fetch( ajaxurl, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: new URLSearchParams( {
+				action: 'slim_seo_redirection_dismiss_deleted_url_notification',
+				nonce: SSRedirectionDeletedURLNotification.nonce,
+				index: notice.dataset.index,
+			} ),
+		} ).catch( () => {} );
+	}
+} );

--- a/js/redirection/deleted-url-notification.js
+++ b/js/redirection/deleted-url-notification.js
@@ -1,15 +1,21 @@
 document.addEventListener( 'click', ( { target } ) => {
+	if ( ! target.classList.contains( 'notice-dismiss' ) ) {
+		return;
+	}
+
 	const notice = target.closest( '.ss-redirection-deleted-url-notification' );
 
-	if ( target.classList.contains( 'notice-dismiss' ) && notice ) {
-		fetch( ajaxurl, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-			body: new URLSearchParams( {
-				action: 'slim_seo_redirection_dismiss_deleted_url_notification',
-				nonce: SSRedirectionDeletedURLNotification.nonce,
-				index: notice.dataset.index,
-			} ),
-		} ).catch( () => {} );
+	if ( ! notice ) {
+		return;
 	}
+
+	fetch( ajaxurl, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: new URLSearchParams( {
+			action: 'slim_seo_redirection_dismiss_deleted_url_notification',
+			nonce: SSRedirectionDeletedURLNotification.nonce,
+			index: notice.dataset.index,
+		} ),
+	} ).catch( () => {} );
 } );

--- a/js/redirection/redirects/Main.js
+++ b/js/redirection/redirects/Main.js
@@ -66,6 +66,8 @@ const List = () => {
 			</div>
 
 			<Items searchKeyword={ searchKeyword } redirectType={ redirectType } executeBulkAction={ executeBulkAction } setExecuteBulkAction={ setExecuteBulkAction } />
+
+			{ SSRedirection?.deleted_url ? <Update redirectToEdit={ { from: SSRedirection.deleted_url } } preOpenModal={ true } /> : '' }
 		</>
 	);
 };

--- a/js/redirection/redirects/Update.js
+++ b/js/redirection/redirects/Update.js
@@ -5,7 +5,7 @@ import { Tooltip } from '../../helper/Tooltip';
 import { fetcher, useApi } from '../helper/misc';
 import ToInput from './ToInput';
 
-const Update = ( { redirectToEdit = {}, children, linkClassName, callback } ) => {
+const Update = ( { redirectToEdit = {}, children, linkClassName, callback, preOpenModal = false } ) => {
 	const [ redirect, setRedirect ] = useState( {} );
 	const [ isProcessing, setIsProcessing ] = useState( false );
 	const [ warningMessage, setWarningMessage ] = useState( '' );
@@ -18,12 +18,18 @@ const Update = ( { redirectToEdit = {}, children, linkClassName, callback } ) =>
 		e.preventDefault();
 		setShowModal( true );
 	};
+
 	const closeModal = () => setShowModal( false );
 
 	const updateRedirect = () => {
 		setWarningMessage( '' );
 
 		fetcher( 'update_redirect', { redirect }, 'POST' ).then( id => {
+			if ( preOpenModal ) {
+				window.location = SSRedirection.settingsURL;
+				return;
+			}
+
 			setShowModal( false );
 			setIsProcessing( false );
 
@@ -80,9 +86,15 @@ const Update = ( { redirectToEdit = {}, children, linkClassName, callback } ) =>
 		setRedirect( { ...SSRedirection.defaultRedirect, ...redirectToEdit } );
 	}, [ redirectToEdit ] );
 
+	useEffect( () => {
+		if ( preOpenModal ) {
+			setShowModal( true );
+		}
+	}, [ preOpenModal ] );
+
 	return (
 		<>
-			<a href='#' className={ linkClassName } onClick={ openModal } title={ title }>{ children ? children : title }</a>
+			{ ! preOpenModal && <a href='#' className={ linkClassName } onClick={ openModal } title={ title }>{ children ? children : title }</a> }
 
 			{
 				showModal && (

--- a/js/redirection/settings/Settings.js
+++ b/js/redirection/settings/Settings.js
@@ -14,6 +14,7 @@ const Settings = () => {
 	const [ redirect404To, setRedirect404To ] = useState( settings[ 'redirect_404_to' ] );
 	const [ redirect404ToURL, setRedirect404ToURL ] = useState( settings[ 'redirect_404_to_url' ] );
 	const [ disableForSinglePosts, toggleDisableForSinglePosts ] = useReducer( onOrOff => !onOrOff, !!settings['disable_for_single_posts'] );
+	const [ enableDeletedURLNotifications, toggleEnableDeletedURLNotifications ] = useReducer( onOrOff => !onOrOff, !!settings['enable_deleted_url_notifications'] );
 
 	const deleteAllRedirects = e => {
 		e.preventDefault();
@@ -165,6 +166,19 @@ const Settings = () => {
 						<td>
 							<label className='ss-toggle'>
 								<input id='ss-disable-for-single-posts' type='checkbox' name={ `${ settingsName }[disable_for_single_posts]` } value='1' checked={ disableForSinglePosts } onChange={ toggleDisableForSinglePosts } />
+								<div className='ss-toggle__switch'></div>
+							</label>
+						</td>
+					</tr>
+
+					<tr>
+						<th scope="row">
+							<label htmlFor="ss-enable-deleted-url-notifications">{ __( 'Deleted URL Notifications', 'slim-seo' ) }</label>
+							<Tooltip content={ __( 'Get notified when content is deleted, so you can create redirects and avoid 404 errors. Supports posts, pages, custom post types, categories, tags, and taxonomy terms.', 'slim-seo' ) } />
+						</th>
+						<td>
+							<label className='ss-toggle'>
+								<input id='ss-enable-deleted-url-notifications' type='checkbox' name={ `${ settingsName }[enable_deleted_url_notifications]` } value='1' checked={ enableDeletedURLNotifications } onChange={ toggleEnableDeletedURLNotifications } />
 								<div className='ss-toggle__switch'></div>
 							</label>
 						</td>

--- a/src/Redirection/Api/Redirects.php
+++ b/src/Redirection/Api/Redirects.php
@@ -4,6 +4,9 @@ namespace SlimSEO\Redirection\Api;
 use WP_REST_Server;
 use WP_REST_Request;
 use SlimSEO\Redirection\Database\Redirects as DbRedirects;
+use SlimSEO\Redirection\Settings;
+use SlimSEO\Redirection\Helper;
+use SlimSEO\Redirection\DeletedURLNotification;
 use SlimSEO\Helpers\Data as DataHelpers;
 
 class Redirects extends Base {
@@ -68,8 +71,13 @@ class Redirects extends Base {
 
 	public function update_redirect( WP_REST_Request $request ): string {
 		$redirect = $request->get_param( 'redirect' );
+		$id       = $this->db_redirects->update( $redirect );
 
-		return $this->db_redirects->update( $redirect );
+		if ( ! empty( $redirect['from'] ) && $id && Settings::get( 'enable_deleted_url_notifications' ) ) {
+			DeletedURLNotification::delete_url( Helper::url_valid( $redirect['from'] ) ? $redirect['from'] : Helper::home_url( $redirect['from'] ) );
+		}
+
+		return $id;
 	}
 
 	public function delete_redirects( WP_REST_Request $request ): bool {

--- a/src/Redirection/DeletedURLNotification.php
+++ b/src/Redirection/DeletedURLNotification.php
@@ -1,0 +1,165 @@
+<?php
+namespace SlimSEO\Redirection;
+
+class DeletedURLNotification {
+	const DELETED_URLS_OPTION_NAME = 'ss_redirection_deleted_urls';
+
+	public function __construct() {
+		add_action( 'wp_trash_post', [ $this, 'trash_post' ] );
+		add_action( 'pre_delete_term', [ $this, 'delete_term' ] );
+		add_action( 'post_updated', [ $this, 'post_updated' ], 10, 3 );
+
+		add_action( 'admin_notices', [ $this, 'notifications' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue' ] );
+		add_action( 'wp_ajax_slim_seo_redirection_dismiss_deleted_url_notification', [ $this, 'dismiss' ] );
+	}
+
+	public function trash_post( int $post_id ): void {
+		$post = get_post( $post_id );
+
+		if ( ! $post || 'publish' !== $post->post_status ) {
+			return;
+		}
+
+		self::add( get_permalink( $post_id ) );
+	}
+
+	public function delete_term( int $term_id ): void {
+		$link = get_term_link( $term_id );
+
+		if ( is_wp_error( $link ) ) {
+			return;
+		}
+
+		self::add( $link, 'term' );
+	}
+
+	public function post_updated( int $post_id, $post_after, $post_before ): void {
+		if ( 'draft' !== $post_before->post_status || 'publish' !== $post_after->post_status ) {
+			return;
+		}
+
+		self::delete_url( get_permalink( $post_id ) );
+	}
+
+	public function notifications(): void {
+		if ( ! $this->has_permission() ) {
+			return;
+		}
+
+		$urls = self::list();
+
+		if ( empty( $urls ) ) {
+			return;
+		}
+
+		foreach ( $urls as $url_index => $url_data ) {
+			?>
+			<div class="ss-redirection-deleted-url-notification notice notice-warning is-dismissible" data-index="<?php echo esc_attr( $url_index ); ?>">
+				<p><strong><?php esc_html_e( 'Slim SEO Redirection:', 'slim-seo' ); ?></strong></p>
+				<p>
+					<?php
+					printf(
+						wp_kses_post(
+							/* translators: 1: content type, 2: deleted URL, 3: redirect URL, 4: link text. */
+							__( 'A %1$s has been moved to trash. You may redirect <code>%2$s</code> to <a href="%3$s">%4$s</a>.', 'slim-seo' )
+						),
+						esc_html( $url_data['type'] ),
+						esc_html( $url_data['url'] ),
+						esc_url( admin_url( "options-general.php?page=slim-seo&deleted_url_index={$url_index}#redirection" ) ),
+						esc_html__( 'a new URL', 'slim-seo' )
+					);
+					?>
+				</p>
+			</div>
+			<?php
+		}
+	}
+
+	public function enqueue(): void {
+		if ( ! $this->has_permission() ) {
+			return;
+		}
+
+		wp_enqueue_script( 'slim-seo-redirection-deleted-url-notification', SLIM_SEO_URL . 'js/redirection/deleted-url-notification.js', [], filemtime( SLIM_SEO_DIR . 'js/redirection/deleted-url-notification.js' ), true );
+		wp_localize_script( 'slim-seo-redirection-deleted-url-notification', 'SSRedirectionDeletedURLNotification', [ 'nonce' => wp_create_nonce( 'slim_seo_dismiss_deleted_url_notification' ) ] );
+	}
+
+	public function dismiss(): void {
+		if ( ! $this->has_permission() ) {
+			wp_send_json_error();
+		}
+
+		check_ajax_referer( 'slim_seo_dismiss_deleted_url_notification', 'nonce' );
+
+		if ( isset( $_POST['index'] ) && is_numeric( $_POST['index'] ) ) {
+			self::delete_index( (int) $_POST['index'] );
+		}
+
+		wp_send_json_success();
+	}
+
+	private static function list(): array {
+		return get_option( self::DELETED_URLS_OPTION_NAME ) ?: [];
+	}
+
+	private static function update( array $urls ): void {
+		update_option( self::DELETED_URLS_OPTION_NAME, $urls );
+	}
+
+	private static function add( string $url, string $type = 'post' ): void {
+		$urls = self::list();
+
+		foreach ( $urls as $url_data ) {
+			if ( $url_data['url'] === $url ) {
+				return;
+			}
+		}
+
+		$urls[] = [
+			'url'  => $url,
+			'type' => $type,
+		];
+
+		self::update( $urls );
+	}
+
+	public static function delete_url( string $url ): void {
+		$urls  = self::list();
+		$found = false;
+
+		foreach ( $urls as $url_index => $url_data ) {
+			if ( $url_data['url'] === $url ) {
+				unset( $urls[ $url_index ] );
+
+				$found = true;
+
+				break;
+			}
+		}
+
+		if ( $found ) {
+			self::update( $urls );
+		}
+	}
+
+	private static function delete_index( int $index ): void {
+		$urls = self::list();
+
+		if ( isset( $urls[ $index ] ) ) {
+			unset( $urls[ $index ] );
+
+			self::update( $urls );
+		}
+	}
+
+	public static function get_url( int $index ): string {
+		$urls = self::list();
+
+		return isset( $urls[ $index ] ) ? ( $urls[ $index ]['url'] ?? '' ) : '';
+	}
+
+	private function has_permission(): bool {
+		return current_user_can( 'manage_options' );
+	}
+}

--- a/src/Redirection/DeletedURLNotification.php
+++ b/src/Redirection/DeletedURLNotification.php
@@ -5,33 +5,37 @@ class DeletedURLNotification {
 	const DELETED_URLS_OPTION_NAME = 'ss_redirection_deleted_urls';
 
 	public function __construct() {
-		add_action( 'wp_trash_post', [ $this, 'trash_post' ] );
+		add_action( 'wp_trash_post', [ $this, 'remove_post' ] );
+		add_action( 'before_delete_post', [ $this, 'remove_post' ] );
 		add_action( 'pre_delete_term', [ $this, 'delete_term' ] );
 		add_action( 'post_updated', [ $this, 'post_updated' ], 10, 3 );
-
 		add_action( 'admin_notices', [ $this, 'notifications' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue' ] );
 		add_action( 'wp_ajax_slim_seo_redirection_dismiss_deleted_url_notification', [ $this, 'dismiss' ] );
 	}
 
-	public function trash_post( int $post_id ): void {
+	public function remove_post( int $post_id ): void {
 		$post = get_post( $post_id );
 
 		if ( ! $post || 'publish' !== $post->post_status ) {
 			return;
 		}
 
-		self::add( get_permalink( $post_id ) );
+		$type = get_post_type_object( $post->post_type )?->labels->singular_name ?? __( 'post', 'slim-seo' );
+
+		self::add( get_permalink( $post_id ), $type );
 	}
 
 	public function delete_term( int $term_id ): void {
-		$link = get_term_link( $term_id );
+		$term = get_term( $term_id );
 
-		if ( is_wp_error( $link ) ) {
+		if ( ! $term || is_wp_error( $term ) ) {
 			return;
 		}
 
-		self::add( $link, 'term' );
+		$type = get_taxonomy( $term->taxonomy )?->labels->singular_name ?? __( 'term', 'slim-seo' );
+
+		self::add( get_term_link( $term ), $type );
 	}
 
 	public function post_updated( int $post_id, $post_after, $post_before ): void {
@@ -62,7 +66,7 @@ class DeletedURLNotification {
 					printf(
 						wp_kses_post(
 							/* translators: 1: content type, 2: deleted URL, 3: redirect URL, 4: link text. */
-							__( 'A %1$s has been moved to trash. You may redirect <code>%2$s</code> to <a href="%3$s">%4$s</a>.', 'slim-seo' )
+							__( 'The %1$s at <code>%2$s</code> has been removed. You may redirect it to <a href="%3$s">%4$s</a>.', 'slim-seo' )
 						),
 						esc_html( $url_data['type'] ),
 						esc_html( $url_data['url'] ),
@@ -104,7 +108,7 @@ class DeletedURLNotification {
 	}
 
 	private static function update( array $urls ): void {
-		update_option( self::DELETED_URLS_OPTION_NAME, $urls );
+		update_option( self::DELETED_URLS_OPTION_NAME, $urls, false );
 	}
 
 	private static function add( string $url, string $type = 'post' ): void {
@@ -125,21 +129,24 @@ class DeletedURLNotification {
 	}
 
 	public static function delete_url( string $url ): void {
-		$urls  = self::list();
-		$found = false;
+		$urls = self::list();
 
-		foreach ( $urls as $url_index => $url_data ) {
-			if ( $url_data['url'] === $url ) {
-				unset( $urls[ $url_index ] );
-
-				$found = true;
-
-				break;
-			}
+		if ( empty( $urls ) ) {
+			return;
 		}
 
-		if ( $found ) {
+		$url_normalized = Helper::normalize_url( $url );
+
+		foreach ( $urls as $url_index => $url_data ) {
+			if ( Helper::normalize_url( $url_data['url'] ) !== $url_normalized ) {
+				continue;
+			}
+
+			unset( $urls[ $url_index ] );
+
 			self::update( $urls );
+
+			return;
 		}
 	}
 

--- a/src/Redirection/DeletedURLNotification.php
+++ b/src/Redirection/DeletedURLNotification.php
@@ -5,8 +5,8 @@ class DeletedURLNotification {
 	const DELETED_URLS_OPTION_NAME = 'ss_redirection_deleted_urls';
 
 	public function __construct() {
-		add_action( 'wp_trash_post', [ $this, 'remove_post' ] );
-		add_action( 'before_delete_post', [ $this, 'remove_post' ] );
+		add_action( 'wp_trash_post', [ $this, 'delete_post' ] );
+		add_action( 'before_delete_post', [ $this, 'delete_post' ] );
 		add_action( 'pre_delete_term', [ $this, 'delete_term' ] );
 		add_action( 'post_updated', [ $this, 'post_updated' ], 10, 3 );
 		add_action( 'admin_notices', [ $this, 'notifications' ] );
@@ -14,14 +14,15 @@ class DeletedURLNotification {
 		add_action( 'wp_ajax_slim_seo_redirection_dismiss_deleted_url_notification', [ $this, 'dismiss' ] );
 	}
 
-	public function remove_post( int $post_id ): void {
+	public function delete_post( int $post_id ): void {
 		$post = get_post( $post_id );
 
 		if ( ! $post || 'publish' !== $post->post_status ) {
 			return;
 		}
 
-		$type = get_post_type_object( $post->post_type )?->labels->singular_name ?? __( 'post', 'slim-seo' );
+		$post_type_object = get_post_type_object( $post->post_type );
+		$type             = $post_type_object && ! empty( $post_type_object->labels->singular_name ) ? $post_type_object->labels->singular_name : __( 'post', 'slim-seo' );
 
 		self::add( get_permalink( $post_id ), $type );
 	}
@@ -33,7 +34,8 @@ class DeletedURLNotification {
 			return;
 		}
 
-		$type = get_taxonomy( $term->taxonomy )?->labels->singular_name ?? __( 'term', 'slim-seo' );
+		$taxonomy = get_taxonomy( $term->taxonomy );
+		$type     = $taxonomy && ! empty( $taxonomy->labels->singular_name ) ? $taxonomy->labels->singular_name : __( 'term', 'slim-seo' );
 
 		self::add( get_term_link( $term ), $type );
 	}
@@ -66,7 +68,7 @@ class DeletedURLNotification {
 					printf(
 						wp_kses_post(
 							/* translators: 1: content type, 2: deleted URL, 3: redirect URL, 4: link text. */
-							__( 'The %1$s at <code>%2$s</code> has been removed. You may redirect it to <a href="%3$s">%4$s</a>.', 'slim-seo' )
+							__( 'The %1$s at <code>%2$s</code> has been deleted. You may redirect it to <a href="%3$s">%4$s</a>.', 'slim-seo' )
 						),
 						esc_html( $url_data['type'] ),
 						esc_html( $url_data['url'] ),

--- a/src/Redirection/Loader.php
+++ b/src/Redirection/Loader.php
@@ -15,6 +15,10 @@ class Loader {
 			if ( ! Settings::get( 'disable_for_single_posts' ) ) {
 				new Post( $this->db_redirects );
 			}
+
+			if ( Settings::get( 'enable_deleted_url_notifications' ) ) {
+				new DeletedURLNotification();
+			}
 		} else {
 			new Redirection( $this->db_redirects );
 			new Redirection404( $this->db_log );

--- a/src/Redirection/Settings.php
+++ b/src/Redirection/Settings.php
@@ -32,7 +32,7 @@ class Settings {
 
 		wp_enqueue_style( 'slim-seo-redirection', SLIM_SEO_URL . 'css/redirection.css', [ 'wp-components' ], filemtime( SLIM_SEO_DIR . 'css/redirection.css' ) );
 
-		Assets::enqueue_build_js( 'redirection', 'SSRedirection', [
+		$data = [
 			'rest'               => untrailingslashit( rest_url() ),
 			'nonce'              => wp_create_nonce( 'wp_rest' ),
 			'homeURL'            => untrailingslashit( home_url() ),
@@ -44,7 +44,21 @@ class Settings {
 			'isLog404TableExist' => $this->db_log->table_exists(),
 			'permalinkUrl'       => admin_url( 'options-permalink.php' ),
 			'defaultRedirect'    => Helper::default_redirect(),
-		] );
+		];
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$deleted_url_index = isset( $_GET['deleted_url_index'] ) ? (int) $_GET['deleted_url_index'] : -1;
+
+		if ( $deleted_url_index >= 0 ) {
+			$deleted_url = DeletedURLNotification::get_url( $deleted_url_index );
+
+			if ( $deleted_url ) {
+				$data['deleted_url'] = $deleted_url;
+				$data['settingsURL'] = admin_url( 'options-general.php?page=slim-seo#redirection' );
+			}
+		}
+
+		Assets::enqueue_build_js( 'redirection', 'SSRedirection', $data );
 
 		do_action( 'slim_seo_redirection_enqueue' );
 		do_action( 'slim_seo_redirection_enqueue_settings' );
@@ -56,6 +70,7 @@ class Settings {
 			'auto_redirection',
 			'enable_404_logs',
 			'disable_for_single_posts',
+			'enable_deleted_url_notifications',
 		];
 
 		foreach ( $checkboxes as $checkbox ) {
@@ -75,14 +90,15 @@ class Settings {
 	public static function list(): array {
 		$saved_settings = get_option( 'slim_seo' ) ?: [];
 		$settings       = [
-			'force_trailing_slash'     => 0,
-			'auto_redirection'         => 1,
-			'redirect_www'             => '',
-			'enable_404_logs'          => 0,
-			'auto_delete_404_logs'     => 30,
-			'redirect_404_to'          => '',
-			'redirect_404_to_url'      => '',
-			'disable_for_single_posts' => 0,
+			'force_trailing_slash'             => 0,
+			'auto_redirection'                 => 1,
+			'redirect_www'                     => '',
+			'enable_404_logs'                  => 0,
+			'auto_delete_404_logs'             => 30,
+			'redirect_404_to'                  => '',
+			'redirect_404_to_url'              => '',
+			'disable_for_single_posts'         => 0,
+			'enable_deleted_url_notifications' => 0,
 		];
 
 		foreach ( $settings as $setting_name => $setting_value ) {

--- a/src/Settings/MetaTags/RestApi.php
+++ b/src/Settings/MetaTags/RestApi.php
@@ -41,6 +41,7 @@ class RestApi {
 			'auto_redirection',
 			'enable_404_logs',
 			'disable_for_single_posts',
+			'enable_deleted_url_notifications',
 			'footer_code',
 			'force_trailing_slash',
 			'header_code',


### PR DESCRIPTION
Track deleted posts and terms, and show admin notifications so users can create redirects to avoid 404 errors. The feature can be enabled/dismissed per notification and automatically clears when a redirect is created for the deleted URL.