### PR TITLE
Fix Metabox modules not outputting in Divi 5

### DIFF
--- a/src/Integrations/Divi.php
+++ b/src/Integrations/Divi.php
@@ -25,10 +25,7 @@ class Divi {
 		}
 
 		$content = $post->post_content;
-
-		if ( ! $this->is_divi_5( $post->ID ) ) {
-			$content = $this->remove_shortcodes( $content );
-		}
+		$content = $this->remove_shortcodes( $content, $post->ID );
 
 		return $content;
 	}
@@ -41,8 +38,8 @@ class Divi {
 		return get_post_meta( $post_id, '_et_pb_use_divi_5', true );
 	}
 
-	private function remove_shortcodes( string $content ): string {
-		return preg_replace( '~\[/?[^\]]+?/?\]~s', '', $content );
+	private function remove_shortcodes( string $content, int $post_id ): string {
+		return $this->is_divi_5( $post_id ) ? preg_replace( '/\[(?:mbdi_field|mbdi_cloneable)\b[^\]]*].*?\[\/(?:mbdi_field|mbdi_cloneable)]/is', '', $content ) : preg_replace( '~\[/?[^\]]+?/?\]~s', '', $content );
 	}
 
 	public function remove_post_types( array $post_types ): array {


### PR DESCRIPTION
## Summary

Previously, shortcode removal was skipped entirely for Divi 5 posts, which caused Metabox module shortcodes to remain in the content. Now Divi 5 posts have only `mbdi_field` and `mbdi_cloneable` shortcodes removed, preserving other shortcodes while fixing the output issue.

## Changes

- Modified `remove_shortcodes` to accept a post ID and apply different regex patterns for Divi 5 vs legacy Divi
- Divi 5: removes only `mbdi_field` and `mbdi_cloneable` shortcodes
- Legacy Divi: continues to remove all shortcodes as before

Co-authored-by: CommandCodeBot <noreply@commandcode.ai>