### PR TITLE
Fix contributor post-meta disclosure in quick edit and meta keys route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ pnpm start
 ## Code Style Guidelines
 
 ### General
-- **Minimum PHP version**: 7.2
+- **Minimum PHP version**: 7.4
 - **Minimum WordPress version**: 6.5
 - **Coding standards**: WordPress Coding Standards (via phpcs.xml)
 - **Text domain**: `slim-seo` (for i18n)

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -101,6 +101,6 @@
 	USE THE PHPCompatibility RULESET
 	#############################################################################
 	-->
-	<config name="testVersion" value="7.2-"/>
+	<config name="testVersion" value="7.4-"/>
 	<rule ref="PHPCompatibilityWP"/>
 </ruleset>

--- a/readme.txt
+++ b/readme.txt
@@ -109,7 +109,7 @@ If you like this plugin, you might also like our other WordPress products:
 
 == Installation ==
 
-Before installing, please note that the plugin requires PHP >= 7.2.
+Before installing, please note that the plugin requires PHP >= 7.4.
 
 1. Go to Plugins > Add New.
 2. Search for "Slim SEO".

--- a/src/MetaTags/AdminColumns/Base.php
+++ b/src/MetaTags/AdminColumns/Base.php
@@ -126,6 +126,10 @@ abstract class Base {
 			wp_send_json_error();
 		}
 
+		if ( ! $this->can_edit( $id ) ) {
+			wp_send_json_error( [], 403 );
+		}
+
 		$data = get_metadata( $this->object_type, $id, 'slim_seo', true ) ?: [];
 		$data = array_merge( [
 			'title'       => '',
@@ -168,4 +172,9 @@ abstract class Base {
 	}
 
 	abstract protected function is_screen(): bool;
+
+	protected function can_edit( int $id ): bool {
+		// phpcs:ignore WordPress.WP.Capabilities.Unknown
+		return $this->object_type === 'term' ? current_user_can( 'edit_term', $id ) : current_user_can( 'edit_post', $id );
+	}
 }

--- a/src/MetaTags/Settings/Preview.php
+++ b/src/MetaTags/Settings/Preview.php
@@ -57,7 +57,17 @@ class Preview {
 
 	public function can_edit_post( WP_REST_Request $request ): bool {
 		$post_id = (int) $request->get_param( 'ID' );
-		return $post_id && current_user_can( 'edit_post', $post_id );
+		if ( ! $post_id ) {
+			return false;
+		}
+
+		if ( current_user_can( 'edit_post', $post_id ) ) {
+			return true;
+		}
+
+		// Contributor previewing their own published post (post_author cannot be spoofed).
+		$post = get_post( $post_id );
+		return $post && 'publish' === $post->post_status && (int) $post->post_author === get_current_user_id();
 	}
 
 	public function can_edit_homepage(): bool {

--- a/src/MetaTags/Settings/Preview.php
+++ b/src/MetaTags/Settings/Preview.php
@@ -65,10 +65,10 @@ class Preview {
 			return true;
 		}
 
-		// Contributor previewing their own published post. post_author = 0 must not match a guest's user ID 0.
+		// Contributor previewing their own published post. Require a logged-in user (post_author = 0 must not match guest ID 0) with the base edit capability (subscriber authors excluded).
 		$user_id = get_current_user_id();
 		$post    = get_post( $post_id );
-		return $post && $user_id > 0 && 'publish' === $post->post_status && (int) $post->post_author === $user_id;
+		return $post && $user_id > 0 && current_user_can( 'edit_posts' ) && 'publish' === $post->post_status && (int) $post->post_author === $user_id;
 	}
 
 	public function can_edit_homepage(): bool {

--- a/src/MetaTags/Settings/Preview.php
+++ b/src/MetaTags/Settings/Preview.php
@@ -65,9 +65,10 @@ class Preview {
 			return true;
 		}
 
-		// Contributor previewing their own published post (post_author cannot be spoofed).
-		$post = get_post( $post_id );
-		return $post && 'publish' === $post->post_status && (int) $post->post_author === get_current_user_id();
+		// Contributor previewing their own published post. post_author = 0 must not match a guest's user ID 0.
+		$user_id = get_current_user_id();
+		$post    = get_post( $post_id );
+		return $post && $user_id > 0 && 'publish' === $post->post_status && (int) $post->post_author === $user_id;
 	}
 
 	public function can_edit_homepage(): bool {

--- a/src/Settings/MetaTags/RestApi.php
+++ b/src/Settings/MetaTags/RestApi.php
@@ -171,6 +171,7 @@ class RestApi {
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$meta_keys = $wpdb->get_col( "SELECT DISTINCT meta_key FROM $wpdb->postmeta ORDER BY meta_key" );
+		$meta_keys = array_filter( $meta_keys, fn( $meta_key ) => ! is_protected_meta( $meta_key, 'post' ) );
 		$meta_keys = $this->exclude_defaults( $meta_keys );
 		$options   = [];
 		foreach ( $meta_keys as $meta_key ) {


### PR DESCRIPTION
## Summary

This PR closes two security gaps in post-meta disclosure. It also restores the Contributor preview of their own published posts.

**Quick-edit handler** (`src/MetaTags/AdminColumns/Base.php`)

The handler read the `slim_seo` meta for any supplied post or term ID. It did not verify the user capability. A Contributor could read the SEO data of another author's draft or private post.

The handler now verifies the capability before the read:
- Posts: `current_user_can( 'edit_post', $id )`
- Terms: `current_user_can( 'edit_term', $id )`

**Meta keys route** (`src/Settings/MetaTags/RestApi.php`)

The `meta-tags/meta_keys` route returned every distinct `meta_key` in `wp_postmeta` site-wide. It now filters out protected keys with `is_protected_meta()`.

**Contributor preview** (`src/MetaTags/Settings/Preview.php`)

Contributors do not have `edit_published_posts`. The preview route therefore blocked their own published posts. The route now allows the author of a published post to preview it. The `post_author` value comes from the database, so it cannot be spoofed.

**PHP version**

The plugin requires PHP 7.4. The `phpcs.xml` testVersion and the docs still declared PHP 7.2. They now match.

## Changelog entries added

- Fix contributor post-meta disclosure in quick edit. Credit Shivamani Vastrala.
- Exclude protected meta keys from the custom field variable picker. Credit Shivamani Vastrala.
